### PR TITLE
Remove check for non-existing attribute.

### DIFF
--- a/app/scripts/views/blocks/inline.js
+++ b/app/scripts/views/blocks/inline.js
@@ -53,7 +53,7 @@ module.exports = {
 
   update_contenteditable: function(){
     var editable = !!this.sidebarLoaded && (Core.state.in_mode('edit', 'edit_shared') ||
-                   Core.state.in_mode('translate') && this.model.get('editable'));
+                   Core.state.in_mode('translate'));
     this.$inline.attr('contenteditable', editable)
   },
 


### PR DESCRIPTION
This attribute was always undefined, but inline content was still editable, because expression was evaluated to undefined and contenteditable attribute wasn't set.